### PR TITLE
rmq

### DIFF
--- a/rmq/logger.go
+++ b/rmq/logger.go
@@ -36,12 +36,15 @@ func (r rlogger) OutputPath(path string) (err error) {
 	return nil
 }
 
-func init() {
+func SetupLogger(level log.Level, pname string) {
 	dl, _ := log.New(log.ZapLogger, []log.Option{ // 根据实际需求添加option
-		log.WithLevelEnabler(log.InfoLevel),
+		log.WithLevelEnabler(level),
 		log.WithEncoderCfg(log.NewEncoderConfig()),
 		log.AddCallerSkip(3),
 		log.AddCaller(),
+		log.Fields(map[string]interface{}{
+			"app": pname,
+		}),
 	}...)
 	rlog.SetLogLevel("info")
 	rlog.SetLogger(&rlogger{


### PR DESCRIPTION
增加rocketmq的producer和consumer池
增加rocketmq的日志级别设置以及项目名初始化

rocketmq的consumer producer接口引用了内部包，搞不了mock就没加单元测试